### PR TITLE
fix(ci): publish on v* tag if release event is skipped

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,12 +1,19 @@
-# This workflow is triggered when a GitHub release is created.
-# It can also be run manually to re-publish to NPM in case it failed for some reason.
-# You can run this workflow by navigating to https://www.github.com/runwayml/sdk-node/actions/workflows/publish-npm.yml
+# Publish when a GitHub release is created, when a v* tag is pushed, or by hand.
+# App-created tags sometimes skip the `release` event (GITHUB_TOKEN / App delivery).
+# `push: tags` is the backup. bin/publish-npm no-ops if the version is already on npm.
+# Manual: https://www.github.com/runwayml/sdk-node/actions/workflows/publish-npm.yml
 name: Publish NPM
 on:
   workflow_dispatch:
-
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -42,6 +42,12 @@ else
   LAST_VERSION=$(echo "$NPM_INFO" | jq -r '.') # strip quotes
 fi
 
+# Tag + release events can both fire. Skip if this version is already on npm.
+if npm view "$PACKAGE_NAME@$VERSION" version >/dev/null 2>&1; then
+  echo "already published $PACKAGE_NAME@$VERSION — skip"
+  exit 0
+fi
+
 # Check if current version is pre-release (e.g. alpha / beta / rc)
 CURRENT_IS_PRERELEASE=false
 if [[ "$VERSION" =~ -([a-zA-Z]+) ]]; then


### PR DESCRIPTION
## Summary
- GitHub `release` events from Stainless App sometimes never start Publish NPM (4.16.1 tag existed; workflow did not run; we dispatched by hand).
- Also run on `push` of `v*` tags. Skip if `@runwayml/sdk` is already that version on npm so tag + release cannot double-fail.

## Test plan
- [ ] Workflow file on `main` after merge (tag/release events read the default branch)
- [ ] Next `v*` tag should start Publish even if `on: release` is silent
- [ ] Re-running publish for an already-published version exits 0